### PR TITLE
feat: add schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,25 @@
         <p>Keep up to date with the <a href="https://ffconf.org/news/">latest announcements here</a></p>
 
         <ol>
+          <li class="break">
+            <div class="time">
+              <time>09:00</time>
+              <time>09:40</time>
+            </div>
+            <p class="title">Registration</p>
+          </li>
+          <li class="break">
+            <div class="time">
+              <time>09:40</time>
+              <time>09:50</time>
+            </div>
+            <p class="title">Opening remarks</p>
+          </li>
           <li class="talk">
+            <div class="time">
+              <time>09:50</time>
+              <time>10:30</time>
+            </div>
             <p class="title">Imposter syndrome, overworking, and working environments <span title="given by">/</span>
               <a href="https://ambershand.co.uk/" class="name">Amber Shand</a>
             </p>
@@ -106,6 +124,11 @@
             </rem-details>
           </li>
           <li class="talk">
+            <div class="time">
+              <time>10:30</time>
+              <time>11:10</time>
+            </div>
+
             <p class="title">The Expanding Dark Forest and Generative <abbr title="artificial intelligence">AI</abbr>
               <span title="given by">/</span>
               <a class="name" href="https://maggieappleton.com/">Maggie Appleton</a>
@@ -126,8 +149,20 @@
               </dl>
             </rem-details>
           </li>
+          <li class="break">
+            <div class="time">
+              <time>11:10</time>
+              <time>11:40</time>
+            </div>
+            <p class="title">Coffee break (30 mins)</p>
+          </li>
 
           <li class="talk">
+            <div class="time">
+              <time>11:40</time>
+              <time>12:20</time>
+            </div>
+
             <p class="title">We need to talk about the front web
               <span title="given by">/</span>
               <a class="name" href="https://gericci.me/">Angela Ricci</a>
@@ -146,6 +181,11 @@
           </li>
 
           <li class="talk">
+            <div class="time">
+              <time>12:20</time>
+              <time>13:00</time>
+            </div>
+
             <p class="title">Web accessibility - it's not just about HTML
               <span title="given by">/</span>
               <a class="name" href="https://ireaderinokun.com/">Ire Aderinokun</a>
@@ -164,7 +204,21 @@
             </rem-details>
           </li>
 
+          <li class="break">
+            <div class="time">
+              <time>13:00</time>
+              <time>14:30</time>
+            </div>
+            <p class="title">Lunch break (90 mins)</p>
+          </li>
+
+
           <li class="talk">
+            <div class="time">
+              <time>14:30</time>
+              <time>15:10</time>
+            </div>
+
             <p class="title">Ada Lovelace and The Very First Computer Program
               <span title="given by">/</span>
               <a class="name" href="https://www.marquisdegeek.com/">Steven Goodwin</a>
@@ -184,6 +238,11 @@
           </li>
 
           <li class="talk">
+            <div class="time">
+              <time>15:10</time>
+              <time>15:50</time>
+            </div>
+
             <p class="title">Embracing Neurodiversity in Tech: Building Empathy, Unveiling Strengths
               <span title="given by">/</span>
               <a class="name" href="https://www.jonathanfielding.com/">Jonathan Fielding</a>
@@ -202,7 +261,21 @@
             </rem-details>
           </li>
 
+          <li class="break">
+            <div class="time">
+              <time>15:50</time>
+              <time>16:15</time>
+            </div>
+            <p class="title">Ice cream break (25 minutes)</p>
+          </li>
+
+
           <li class="talk">
+            <div class="time">
+              <time>16:15</time>
+              <time>16:55</time>
+            </div>
+
             <p class="title">Exploring the Potential of the Web Speech API in Karaoke
               <span title="given by">/</span>
               <a class="name" href="https://ohhelloana.blog/">Ana Rodrigues</a>
@@ -223,6 +296,11 @@
             </rem-details>
           </li>
           <li class="talk">
+            <div class="time">
+              <time>16:55</time>
+              <time>17:35</time>
+            </div>
+
             <p class="title">Entertainment as Code
               <span title="given by">/</span>
               <a class="name" href="https://whitep4nth3r.com/">Salma Alam-Naylor</a>
@@ -241,6 +319,22 @@
               </dl>
             </rem-details>
           </li>
+
+          <li class="break">
+            <div class="time">
+              <time>17:35</time>
+              <time>17:50</time>
+            </div>
+            <p class="title">Closing remarks</p>
+          </li>
+          <li class="break">
+            <div class="time">
+              <time>17:50</time>
+              <time datetime="23:59:00">Late</time>
+            </div>
+            <p class="title">Post social</p>
+          </li>
+
 
         </ol>
       </section>

--- a/style.css
+++ b/style.css
@@ -372,11 +372,11 @@ ul li:last-child {
   display: none;
   grid-area: a;
   width: 100%;
-  cursor: help;
+  /* cursor: help; */
   border: 4px solid var(--c-gold);
   position: relative;
 
-  &:after {
+  DISABLED_&:after {
     content: '';
     height: 100%;
     width: 100%;
@@ -524,14 +524,15 @@ ul li:last-child {
     display: grid;
     gap: 32px 64px;
     grid-template-areas:
-      'a b'
+      'time title'
+      /* 'a b' */
       'a c';
     /*     grid-template-columns: 326px 1fr; */
     grid-template-columns: 256px 1fr;
   }
 
   #schedule li.break {
-    grid-template-areas: 'a b';
+    grid-template-areas: 'time title';
   }
 
   rem-details {
@@ -539,7 +540,7 @@ ul li:last-child {
   }
 
   #schedule .time {
-    grid-area: a;
+    grid-area: time;
     max-width: 326px;
     align-self: start;
   }
@@ -549,13 +550,13 @@ ul li:last-child {
   }
 
   #schedule .title {
-    grid-area: b;
+    grid-area: title;
     /* width: 100%; */
     margin-top: 0px;
   }
 
   .time {
-    width: 424px;
+    /* width: 424px; */
   }
 }
 


### PR DESCRIPTION
**🧑‍💻👉 [Live preview url](https://deploy-preview-1--ffconf2023.netlify.app/)**

<img width="1462" alt="SCR-20231031-jugm" src="https://github.com/leftlogic/ffconf2023/assets/13700/f8a61dde-f223-4c89-a284-371d70bb217e">

I think since I've got larger photos of the speakers, maybe dropping the end-time and the bar (except for the very last "post social") might reduce the noise.